### PR TITLE
Reduced postgres shared memory to 128MB from 2560MB

### DIFF
--- a/CoreConfig.xml
+++ b/CoreConfig.xml
@@ -17,7 +17,7 @@
     <submission ignoreStaleMessages="false" validateXml="false"/>
     <subscription reloadPersistent="false"/>
     <repository enable="true" numDbConnections="16" connectionPoolAutoSize="true" primaryKeyBatchSize="500" insertionBatchSize="500" archive="false">
-        <connection url="jdbc:postgresql://tak-database:5432/cot" username="martiuser" password="A4qs6s5MsZ06VasUmE!"/>
+        <connection url="jdbc:postgresql://HOSTIP:5432/cot" username="martiuser" password="A4qs6s5MsZ06VasUmE!"/>
     </repository>
     <repeater enable="true" periodMillis="3000" staleDelayMillis="15000">
         <repeatableType initiate-test="/event/detail/emergency[@type='911 Alert']" cancel-test="/event/detail/emergency[@cancel='true']" _name="911"/>
@@ -27,7 +27,7 @@
     </repeater>
     <filter>
         <thumbnail/>
-        <urladd host="http://192.168.64.3:8080"/>
+        <urladd host="https://HOSTIP:8433"/>
         <flowtag enable="false" text=""/>
         <streamingbroker enable="true"/>
         <scrubber enable="false" action="overwrite"/>
@@ -71,7 +71,7 @@
         <tls keystore="JKS" keystoreFile="/opt/tak/certs/files/takserver.jks" keystorePass="atakatak" truststore="JKS" truststoreFile="/opt/tak/certs/files/truststore-root.jks" truststorePass="atakatak" context="TLSv1.2" keymanager="SunX509"/>
     </security>
     <federation missionFederationDisruptionToleranceRecencySeconds="43200">
-        <federation-server webBaseUrl="https://192.168.64.3:8443/Marti">
+        <federation-server webBaseUrl="https://HOSTIP:8443/Marti">
             <tls keystore="JKS" keystoreFile="/opt/tak/certs/files/takserver.jks" keystorePass="atakatak" truststore="JKS" truststoreFile="certs/files/fed-truststore.jks" truststorePass="atakatak" keymanager="SunX509"/>
             <v1Tls tlsVersion="TLSv1.2"/>
             <v1Tls tlsVersion="TLSv1.3"/>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The size blew up after 4.6 due to 900GB of DTED which was added to webtak.
 ## Requirements
 - Docker
 - A TAK server release
-- 4GB memory
+- 2GB memory
 - Network connection 
 - unzip and netstat utilities
 
@@ -169,6 +169,16 @@ If you've never setup ATAK with a server before you need server and user certifi
 You can find ready made data packages in the tak/certs/files folder. You need to copy these to your device's SD card then import the .zip into ATAK / iTAK with the "import" function and choose "Local SD".
 
 This will add a server, certificates and a user account. You will still need to create this user with the matching name eg. user1 in your TAK server user management dashboard and assign them to a common group.
+
+### Transferring your ZIP files via HTTP
+If you like to live dangerously, you can run a script to serve the .zip files on TCP port 12345. eg. http://0.0.0.0:12345 This launches a mini Python web server and serves the content of the 'share' folder which will contain your certificates. Note that sharing certificates via insecure protocols is not secure. 
+
+    ./scripts/shareCerts.sh
+    Serving HTTP on 0.0.0.0 port 12345 (http://0.0.0.0:12345/) ...
+    10.0.0.5 - - [23/Nov/2022 15:49:52] "GET / HTTP/1.1" 200 -
+    10.0.0.5 - - [23/Nov/2022 15:49:54] "GET /user1-10.0.0.3.dp.zip HTTP/1.1" 200 
+
+Stop the script with Ctrl-C once done to stop randoms fetching your certs.
 
 # FAQ
 See [Frequently asked questions](FAQ.md)

--- a/postgresql1.conf
+++ b/postgresql1.conf
@@ -61,7 +61,7 @@ listen_addresses = '*'	# what IP address(es) to listen on;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 #port = 5432				# (change requires restart)
-max_connections = 2100			# (change requires restart)
+max_connections = 100			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/var/run/postgresql, /tmp'	# comma-separated list of directories
 					# (change requires restart)
@@ -110,7 +110,7 @@ tcpip_socket = true
 
 # - Memory -
 
-shared_buffers = 2560MB			# min 128kB
+shared_buffers = 128MB			# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)

--- a/scripts/configureInDocker1.sh
+++ b/scripts/configureInDocker1.sh
@@ -2,6 +2,7 @@
 
 # Added for 4.7 REL 18 where they broke DB auth
 #sed -i 's/127.0.0.1\/32/0.0.0.0\/0/g' /opt/tak/db-utils/pg_hba.conf
+# Removed inline options because these belong in postgres.conf
 
 if [ -f "/var/lib/postgresql/data/postgresql.conf" ];
 then
@@ -9,7 +10,7 @@ then
 	rm -f /var/lib/postgresql/data/postmaster.pid
 	echo "listen_addresses='*'" >> /var/lib/postgresql/data/postgresql.conf
 	cp /opt/tak/db-utils/pg_hba.conf /var/lib/postgresql/data/pg_hba.conf
-	su - postgres -c "/usr/lib/postgresql/14/bin/pg_ctl -D /var/lib/postgresql/data -l logfile start -o '-c max_connections=2100 -c shared_buffers=2560MB'"
+	su - postgres -c "/usr/lib/postgresql/14/bin/pg_ctl -D /var/lib/postgresql/data -l logfile start"
 
 else
 
@@ -17,7 +18,7 @@ else
 	chown postgres:postgres /var/lib/postgresql/data
 	su - postgres -c '/usr/lib/postgresql/14/bin/pg_ctl initdb -D /var/lib/postgresql/data'
 	cp /opt/tak/db-utils/pg_hba.conf /var/lib/postgresql/data/pg_hba.conf
-	su - postgres -c "/usr/lib/postgresql/14/bin/pg_ctl -D /var/lib/postgresql/data -l logfile start -o '-c max_connections=2100 -c shared_buffers=2560MB'"	
+	su - postgres -c "/usr/lib/postgresql/14/bin/pg_ctl -D /var/lib/postgresql/data -l logfile start"	
 
 	cd /opt/tak/db-utils
 	./configure.sh


### PR DESCRIPTION
- Edited postgres conf to reduce absurd memory requirement
- Removed hardcoded postgres memory options in startup scripts
- Added mini web server to deploy setup data packages
- Fixed startup race condition which caused https 8443 to fail to http 8080