### PR TITLE
Ubuntu 22.04 requires ZIP package so setup.sh can create data packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The size blew up after 4.6 due to 900GB of DTED which was added to webtak.
 ## Installation
 Fetch the dependencies, then the git repo and cd into the directory
 
-    apt-get install docker-compose unzip net-tools
+    apt-get install docker-compose unzip zip net-tools
     git clone https://github.com/Cloud-RF/tak-server.git
     cd tak-server
 


### PR DESCRIPTION
- Documentation update: ZIP package is required to use "zip" command during data package creation in the setup.sh.