### PR TITLE
Add sbin to PATH for ifconfig

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -158,6 +158,7 @@ then
 fi
 
 # ifconfig?
+export PATH=$PATH:/sbin
 if ! command -v ifconfig
 then
 	printf $danger "\nRTFM: You need net-tools: apt-get install net-tools\n"


### PR DESCRIPTION
Current base install of Debian 12net install does not include /sbin to the path for regular users, so ifconfig fails to run. The message tells the user to install net-tools as a result. Added sbin to path so that the regular user can run ifconfig.