### PR TITLE
Quick checksum file update to support current release as of 2024-11-13 @ 2131 US/Pacific Time

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 color() {
     STARTCOLOR="\e[$2";

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,7 +39,7 @@ netstat_check () {
 	
 	ports=(5432 8089 8443 8444 8446 9000 9001)
 	
-	for i in "${ports[@]};"
+	for i in ${ports[@]};
 	do
 		netstat -lant | grep -w $i
 		if [ $? -eq 0 ];

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,7 +39,7 @@ netstat_check () {
 	
 	ports=(5432 8089 8443 8444 8446 9000 9001)
 	
-	for i in ${ports[@]};
+	for i in "${ports[@]};"
 	do
 		netstat -lant | grep -w $i
 		if [ $? -eq 0 ];

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 color() {
     STARTCOLOR="\e[$2";

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,19 +19,19 @@ then
 fi
 
 
-printf $success "\nTAK server setup script sponsored by CloudRF.com - \"The API for RF\"\n"
-printf $info "\nStep 1. Download the official docker image as a zip file from https://tak.gov/products/tak-server \nStep 2. Place the zip file in this tak-server folder.\n"
-# printf $warning "\nYou should install this as a user. Elevated privileges (sudo) are only required to clean up a previous install eg. sudo ./scripts/cleanup.sh\n"
+printf "%s\n" "$success" "\nTAK server setup script sponsored by CloudRF.com - \"The API for RF\"\n"
+printf "%s\n" "$info" "\nStep 1. Download the official docker image as a zip file from https://tak.gov/products/tak-server \nStep 2. Place the zip file in this tak-server folder.\n"
+# printf "%s\n" "$warning" "\nYou should install this as a user. Elevated privileges (sudo) are only required to clean up a previous install eg. sudo ./scripts/cleanup.sh\n"
 
 arch=$(dpkg --print-architecture)
 
 DOCKERFILE=docker-compose.yml
 
-if [ $arch == "arm64" ];
-then
-	DOCKERFILE=docker-compose.arm.yml
-	printf "\nBuilding for arm64...\n" "info"
+if [ "$arch" == "arm64" ]; then
+    DOCKERFILE="docker-compose.arm.yml"
+    printf "%s\n" "$info" "Building for arm64..."
 fi
+
 
 
 ### Check if required ports are in use by anything other than docker
@@ -44,10 +44,10 @@ netstat_check () {
 		netstat -lant | grep -w $i
 		if [ $? -eq 0 ];
 		then
-			printf $warning "\nAnother process is still using port $i. Either wait or use 'sudo netstat -plant' to find it, then 'ps aux' to get the PID and 'kill PID' to stop it and try again\n"
+			printf "%s\n" "$warning" "\nAnother process is still using port $i. Either wait or use 'sudo netstat -plant' to find it, then 'ps aux' to get the PID and 'kill PID' to stop it and try again\n"
 			exit 0
 		else
-			printf $success "\nPort $i is available.."
+			printf "%s\n" "$success" "\nPort $i is available.."
 		fi
 	done
 	
@@ -57,7 +57,7 @@ tak_folder () {
 	### Check if the folder "tak" exists after previous install or attempt and remove it or leave it for the user to decide
 	if [ -d "./tak" ] 
 	then
-	    printf $warning "\nDirectory 'tak' already exists. This will be removed along with the docker volume, do you want to continue? (y/n): "
+	    printf "%s\n" "$warning" "\nDirectory 'tak' already exists. This will be removed along with the docker volume, do you want to continue? (y/n): "
 	    read dirc
 	    if [ $dirc == "n" ];
 	    then
@@ -83,7 +83,7 @@ checksum () {
 
 	if [ "$(ls -hl *-RELEASE-*.zip 2>/dev/null)" ];
 	then
-		printf $warning "SECURITY WARNING: Make sure the checksums match! You should only download your release from a trusted source eg. tak.gov:\n"
+		printf "%s\n" "$warning" "SECURITY WARNING: Make sure the checksums match! You should only download your release from a trusted source eg. tak.gov:\n"
 		for file in *.zip;
 		do
 			printf "Computed SHA1 Checksum: "
@@ -97,7 +97,7 @@ checksum () {
 		sha1sum --ignore-missing -c tak-sha1checksum.txt
 		if [ $? -ne 0 ];
 		then
-			printf $danger "SECURITY WARNING: The file is either different OR is not listed in the known releases.\nDo you really want to continue with this setup? (y/n): "
+			printf "%s\n" "$danger" "SECURITY WARNING: The file is either different OR is not listed in the known releases.\nDo you really want to continue with this setup? (y/n): "
 			read check
 			if [ "$check" == "n" ];
 			then
@@ -113,7 +113,7 @@ checksum () {
 		md5sum --ignore-missing -c tak-md5checksum.txt
 		if [ $? -ne 0 ];
 		then
-			printf $danger "SECURITY WARNING: The checksum is not correct, so the file is different. Do you really want to continue with this setup? (y/n): "
+			printf "%s\n" "$danger" "SECURITY WARNING: The checksum is not correct, so the file is different. Do you really want to continue with this setup? (y/n): "
 			read check
 			if [ "$check" == "n" ];
 			then
@@ -126,7 +126,7 @@ checksum () {
 			fi
 		fi
 	else
-		printf $danger "\n\tPlease download the release of docker image as per instructions in README.md file. Exiting now...\n\n"
+		printf "%s\n" "$danger" "\n\tPlease download the release of docker image as per instructions in README.md file. Exiting now...\n\n"
 		sleep 1
 		exit 0
 	fi
@@ -136,7 +136,7 @@ netstat_check
 tak_folder
 if [ -d "tak" ] 
 then
-	printf $danger "Failed to remove the tak folder. You will need to do this as sudo: sudo ./scripts/cleanup.sh\n"
+	printf "%s\n" "$danger" "Failed to remove the tak folder. You will need to do this as sudo: sudo ./scripts/cleanup.sh\n"
 	exit 0
 fi
 checksum
@@ -147,7 +147,9 @@ checksum
 
 release=$(ls -hl *.zip | awk '{print $9}' | cut -d. -f -2)
 
-printf $warning "\nPausing to let you know release version $release will be setup in 5 seconds.\nIf this is wrong, hit Ctrl-C now..." 
+printf "%s\n" "$warning" "Pausing to let you know release version $release will be setup in 5 seconds."
+printf "%s\n" "$warning" "If this is wrong, hit Ctrl-C now..."
+
 sleep 5
 
 
@@ -161,7 +163,7 @@ fi
 export PATH=$PATH:/sbin
 if ! command -v ifconfig
 then
-	printf $danger "\nRTFM: You need net-tools: apt-get install net-tools\n"
+	printf "%s\n" "$danger" "RTFM: You need net-tools: apt-get install net-tools"
 	exit 1
 fi
 
@@ -170,20 +172,22 @@ if ! command -v unzip
 then
 	if ! command -v 7z
 	then
-		printf $danger "\n .----------------.  .----------------.  .----------------.  .----------------.\n" 
-		printf $danger "| .--------------. || .--------------. || .--------------. || .--------------. |\n"
-		printf $danger "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |\n"
-		printf $danger "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |\n"
-		printf $danger "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |\n"
-		printf $danger "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |\n"
-		printf $danger "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |\n"
-		printf $danger "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |\n"
-		printf $danger "| |              | || |              | || |              | || |              | |\n"
-		printf $danger "| '--------------' || '--------------' || '--------------' || '--------------' |\n"
-		printf $danger " '----------------'  '----------------'  '----------------'  '----------------' \n"
-		printf $danger "You require either unzip OR 7z to decompress the TAK release\n"
-		printf $danger "https://github.com/Cloud-RF/tak-server/blob/main/README.md\n"
+		printf "%s\n" "$danger" ""
+		printf "%s\n" "$danger" " .----------------.  .----------------.  .----------------.  .----------------."
+		printf "%s\n" "$danger" "| .--------------. || .--------------. || .--------------. || .--------------. |"
+		printf "%s\n" "$danger" "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |"
+		printf "%s\n" "$danger" "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |"
+		printf "%s\n" "$danger" "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |"
+		printf "%s\n" "$danger" "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |"
+		printf "%s\n" "$danger" "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |"
+		printf "%s\n" "$danger" "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |"
+		printf "%s\n" "$danger" "| |              | || |              | || |              | || |              | |"
+		printf "%s\n" "$danger" "| '--------------' || '--------------' || '--------------' || '--------------' |"
+		printf "%s\n" "$danger" " '----------------'  '----------------'  '----------------'  '----------------' "
+		printf "%s\n" "$danger" "You require either unzip OR 7z to decompress the TAK release"
+		printf "%s\n" "$danger" "https://github.com/Cloud-RF/tak-server/blob/main/README.md"
 		exit 1
+
 	else
 		7z x $release.zip -o/tmp/takserver
 	fi
@@ -193,19 +197,20 @@ fi
 
 if [ ! -d "/tmp/takserver/$release/tak" ] 
 then
-	printf $danger "\n .----------------.  .----------------.  .----------------.  .----------------.\n" 
-	printf $danger "| .--------------. || .--------------. || .--------------. || .--------------. |\n"
-	printf $danger "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |\n"
-	printf $danger "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |\n"
-	printf $danger "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |\n"
-	printf $danger "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |\n"
-	printf $danger "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |\n"
-	printf $danger "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |\n"
-	printf $danger "| |              | || |              | || |              | || |              | |\n"
-	printf $danger "| '--------------' || '--------------' || '--------------' || '--------------' |\n"
-	printf $danger " '----------------'  '----------------'  '----------------'  '----------------' \n"
-	printf $danger "A decompressed folder was NOT found at /tmp/takserver/$release\n"
-	printf $danger "https://github.com/Cloud-RF/tak-server/blob/main/README.md\n"
+	printf "%s\n" "$danger" ""
+	printf "%s\n" "$danger" " .----------------.  .----------------.  .----------------.  .----------------."
+	printf "%s\n" "$danger" "| .--------------. || .--------------. || .--------------. || .--------------. |"
+	printf "%s\n" "$danger" "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |"
+	printf "%s\n" "$danger" "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |"
+	printf "%s\n" "$danger" "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |"
+	printf "%s\n" "$danger" "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |"
+	printf "%s\n" "$danger" "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |"
+	printf "%s\n" "$danger" "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |"
+	printf "%s\n" "$danger" "| |              | || |              | || |              | || |              | |"
+	printf "%s\n" "$danger" "| '--------------' || '--------------' || '--------------' || '--------------' |"
+	printf "%s\n" "$danger" " '----------------'  '----------------'  '----------------'  '----------------' "
+	printf "%s\n" "$danger" "A decompressed folder was NOT found at /tmp/takserver/$release"
+	printf "%s\n" "$danger" "https://github.com/Cloud-RF/tak-server/blob/main/README.md"
 	exit 1
 fi
 
@@ -234,7 +239,7 @@ pgpassword=$pgpwd"Meh1!"
 NIC=$(route | grep default | awk '{print $8}' | head -n 1)
 IP=$(ip addr show $NIC | grep -m 1 "inet " | awk '{print $2}' | cut -d "/" -f1)
 
-printf $info "\nProceeding with IP address: $IP\n"
+printf "%s\n" "$info" "\nProceeding with IP address: $IP\n"
 sed -i "s/password=\".*\"/password=\"${pgpassword}\"/" tak/CoreConfig.xml
 # Replaces HOSTIP for rate limiter and Fed server. Database URL is a docker alias of tak-database
 sed -i "s/HOSTIP/$IP/g" tak/CoreConfig.xml
@@ -255,7 +260,7 @@ fi
 sed -i "s%\`awk '/MemTotal/ {print \$2}' /proc/meminfo\`%$mem%g" tak/setenv.sh
 
 ## Set variables for generating CA and client certs
-printf $warning "SSL setup. Hit enter (x4) to accept the defaults:\n"
+printf "%s\n" "$warning" "SSL setup. Hit enter (x4) to accept the defaults:\n"
 read -p "Country (for cert generation). Default [US] : " country
 read -p "State (for cert generation). Default [state] : " state
 read -p "City (for cert generation). Default [city]: " city
@@ -307,7 +312,7 @@ $DOCKER_COMPOSE --file $DOCKERFILE up  --force-recreate -d
 while :
 do
 	sleep 10 # let the PG stderr messages conclude...
-	printf $warning "------------CERTIFICATE GENERATION--------------\n"
+	printf "%s\n" "$warning" "------------CERTIFICATE GENERATION--------------"
 	$DOCKER_COMPOSE exec tak bash -c "cd /opt/tak/certs && ./makeRootCa.sh --ca-name CRFtakserver"
 	if [ $? -eq 0 ];
 	then
@@ -330,7 +335,7 @@ do
 	fi
 done
 
-printf $info "Creating certificates for 2 users in tak/certs/files for a quick setup via TAK's import function\n"
+printf "%s\n" "$info" "Creating certificates for 2 users in tak/certs/files for a quick setup via TAK's import function\n"
 
 # Make 2 users
 cd tak/certs
@@ -343,7 +348,7 @@ cd ../../
 ./scripts/certDP.sh $IP user1
 ./scripts/certDP.sh $IP user2
 
-printf $info "Waiting for TAK server to go live. This should take <1m with an AMD64, ~2min on a ARM64 (Pi)\n"
+printf "%s\n" "$info" "Waiting for TAK server to go live. This should take <1m with an AMD64, ~2min on an ARM64 (Pi)"
 $DOCKER_COMPOSE start tak
 sleep 10
 
@@ -369,7 +374,7 @@ do
 			sleep 10
 		fi
 	else
-		printf $info "No joy with DB at $IP, will retry in 10s. If this loops more than 6 times go and get some fresh air...\n" 
+		printf "%s\n" "$info" "No joy with DB at $IP, will retry in 10s. If this loops more than 6 times, go and get some fresh air..." 
 	fi
 done
 
@@ -378,15 +383,15 @@ cp ./tak/certs/files/$user.p12 .
 ### Post-installation message to user including randomly generated passwrods to use for account and PostgreSQL
 docker container ls
 
-printf $warning "\n\nImport the $user.p12 certificate from this folder to your browser as per the README.md file\n"
-printf $success "Login at https://$IP:8443 with your admin account. No need to run the /setup step as this has been done.\n" 
-printf $info "Certificates and *CERT DATA PACKAGES* are in tak/certs/files \n\n" 
-printf $success "Setup script sponsored by CloudRF.com - \"The API for RF\"\n\n"
-printf $danger "---------PASSWORDS----------------\n\n"
-printf $danger "Admin user name: $user\n" # Web interface default user name
-printf $danger "Admin password: $password\n" # Web interface default random password created during setup
-printf $danger "PostgreSQL password: $pgpassword\n\n" # PostgreSQL password randomly generated during set up
-printf $danger "---------PASSWORDS----------------\n\n"
-printf $warning "MAKE A NOTE OF YOUR PASSWORDS. THEY WON'T BE SHOWN AGAIN.\n"
-printf $warning "You have a database listening on TCP 5432 which requires a login. You should still block this port with a firewall\n"
-printf $info "Docker containers should automatically start with the Docker service from now on.\n"
+printf "%s\n\n" "$warning" "Import the $user.p12 certificate from this folder to your browser as per the README.md file"
+printf "%s\n" "$success" "Login at https://$IP:8443 with your admin account. No need to run the /setup step as this has been done."
+printf "%s\n\n" "$info" "Certificates and *CERT DATA PACKAGES* are in tak/certs/files"
+printf "%s\n\n" "$success" "Setup script sponsored by CloudRF.com - \"The API for RF\""
+printf "%s\n\n" "$danger" "---------PASSWORDS----------------"
+printf "%s\n" "$danger" "Admin user name: $user" # Web interface default user name
+printf "%s\n" "$danger" "Admin password: $password" # Web interface default random password created during setup
+printf "%s\n\n" "$danger" "PostgreSQL password: $pgpassword" # PostgreSQL password randomly generated during setup
+printf "%s\n\n" "$danger" "---------PASSWORDS----------------"
+printf "%s\n" "$warning" "MAKE A NOTE OF YOUR PASSWORDS. THEY WON'T BE SHOWN AGAIN."
+printf "%s\n" "$warning" "You have a database listening on TCP 5432 which requires a login. You should still block this port with a firewall"
+printf "%s\n" "$info" "Docker containers should automatically start with the Docker service from now on."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,19 +19,19 @@ then
 fi
 
 
-printf "%s\n" "$success" "\nTAK server setup script sponsored by CloudRF.com - \"The API for RF\"\n"
-printf "%s\n" "$info" "\nStep 1. Download the official docker image as a zip file from https://tak.gov/products/tak-server \nStep 2. Place the zip file in this tak-server folder.\n"
-# printf "%s\n" "$warning" "\nYou should install this as a user. Elevated privileges (sudo) are only required to clean up a previous install eg. sudo ./scripts/cleanup.sh\n"
+printf $success "\nTAK server setup script sponsored by CloudRF.com - \"The API for RF\"\n"
+printf $info "\nStep 1. Download the official docker image as a zip file from https://tak.gov/products/tak-server \nStep 2. Place the zip file in this tak-server folder.\n"
+# printf $warning "\nYou should install this as a user. Elevated privileges (sudo) are only required to clean up a previous install eg. sudo ./scripts/cleanup.sh\n"
 
 arch=$(dpkg --print-architecture)
 
 DOCKERFILE=docker-compose.yml
 
-if [ "$arch" == "arm64" ]; then
-    DOCKERFILE="docker-compose.arm.yml"
-    printf "%s\n" "$info" "Building for arm64..."
+if [ $arch == "arm64" ];
+then
+	DOCKERFILE=docker-compose.arm.yml
+	printf "\nBuilding for arm64...\n" "info"
 fi
-
 
 
 ### Check if required ports are in use by anything other than docker
@@ -44,10 +44,10 @@ netstat_check () {
 		netstat -lant | grep -w $i
 		if [ $? -eq 0 ];
 		then
-			printf "%s\n" "$warning" "\nAnother process is still using port $i. Either wait or use 'sudo netstat -plant' to find it, then 'ps aux' to get the PID and 'kill PID' to stop it and try again\n"
+			printf $warning "\nAnother process is still using port $i. Either wait or use 'sudo netstat -plant' to find it, then 'ps aux' to get the PID and 'kill PID' to stop it and try again\n"
 			exit 0
 		else
-			printf "%s\n" "$success" "\nPort $i is available.."
+			printf $success "\nPort $i is available.."
 		fi
 	done
 	
@@ -57,7 +57,7 @@ tak_folder () {
 	### Check if the folder "tak" exists after previous install or attempt and remove it or leave it for the user to decide
 	if [ -d "./tak" ] 
 	then
-	    printf "%s\n" "$warning" "\nDirectory 'tak' already exists. This will be removed along with the docker volume, do you want to continue? (y/n): "
+	    printf $warning "\nDirectory 'tak' already exists. This will be removed along with the docker volume, do you want to continue? (y/n): "
 	    read dirc
 	    if [ $dirc == "n" ];
 	    then
@@ -83,7 +83,7 @@ checksum () {
 
 	if [ "$(ls -hl *-RELEASE-*.zip 2>/dev/null)" ];
 	then
-		printf "%s\n" "$warning" "SECURITY WARNING: Make sure the checksums match! You should only download your release from a trusted source eg. tak.gov:\n"
+		printf $warning "SECURITY WARNING: Make sure the checksums match! You should only download your release from a trusted source eg. tak.gov:\n"
 		for file in *.zip;
 		do
 			printf "Computed SHA1 Checksum: "
@@ -97,7 +97,7 @@ checksum () {
 		sha1sum --ignore-missing -c tak-sha1checksum.txt
 		if [ $? -ne 0 ];
 		then
-			printf "%s\n" "$danger" "SECURITY WARNING: The file is either different OR is not listed in the known releases.\nDo you really want to continue with this setup? (y/n): "
+			printf $danger "SECURITY WARNING: The file is either different OR is not listed in the known releases.\nDo you really want to continue with this setup? (y/n): "
 			read check
 			if [ "$check" == "n" ];
 			then
@@ -113,7 +113,7 @@ checksum () {
 		md5sum --ignore-missing -c tak-md5checksum.txt
 		if [ $? -ne 0 ];
 		then
-			printf "%s\n" "$danger" "SECURITY WARNING: The checksum is not correct, so the file is different. Do you really want to continue with this setup? (y/n): "
+			printf $danger "SECURITY WARNING: The checksum is not correct, so the file is different. Do you really want to continue with this setup? (y/n): "
 			read check
 			if [ "$check" == "n" ];
 			then
@@ -126,7 +126,7 @@ checksum () {
 			fi
 		fi
 	else
-		printf "%s\n" "$danger" "\n\tPlease download the release of docker image as per instructions in README.md file. Exiting now...\n\n"
+		printf $danger "\n\tPlease download the release of docker image as per instructions in README.md file. Exiting now...\n\n"
 		sleep 1
 		exit 0
 	fi
@@ -136,7 +136,7 @@ netstat_check
 tak_folder
 if [ -d "tak" ] 
 then
-	printf "%s\n" "$danger" "Failed to remove the tak folder. You will need to do this as sudo: sudo ./scripts/cleanup.sh\n"
+	printf $danger "Failed to remove the tak folder. You will need to do this as sudo: sudo ./scripts/cleanup.sh\n"
 	exit 0
 fi
 checksum
@@ -147,9 +147,7 @@ checksum
 
 release=$(ls -hl *.zip | awk '{print $9}' | cut -d. -f -2)
 
-printf "%s\n" "$warning" "Pausing to let you know release version $release will be setup in 5 seconds."
-printf "%s\n" "$warning" "If this is wrong, hit Ctrl-C now..."
-
+printf $warning "\nPausing to let you know release version $release will be setup in 5 seconds.\nIf this is wrong, hit Ctrl-C now..." 
 sleep 5
 
 
@@ -163,7 +161,7 @@ fi
 export PATH=$PATH:/sbin
 if ! command -v ifconfig
 then
-	printf "%s\n" "$danger" "RTFM: You need net-tools: apt-get install net-tools"
+	printf $danger "\nRTFM: You need net-tools: apt-get install net-tools\n"
 	exit 1
 fi
 
@@ -172,22 +170,20 @@ if ! command -v unzip
 then
 	if ! command -v 7z
 	then
-		printf "%s\n" "$danger" ""
-		printf "%s\n" "$danger" " .----------------.  .----------------.  .----------------.  .----------------."
-		printf "%s\n" "$danger" "| .--------------. || .--------------. || .--------------. || .--------------. |"
-		printf "%s\n" "$danger" "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |"
-		printf "%s\n" "$danger" "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |"
-		printf "%s\n" "$danger" "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |"
-		printf "%s\n" "$danger" "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |"
-		printf "%s\n" "$danger" "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |"
-		printf "%s\n" "$danger" "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |"
-		printf "%s\n" "$danger" "| |              | || |              | || |              | || |              | |"
-		printf "%s\n" "$danger" "| '--------------' || '--------------' || '--------------' || '--------------' |"
-		printf "%s\n" "$danger" " '----------------'  '----------------'  '----------------'  '----------------' "
-		printf "%s\n" "$danger" "You require either unzip OR 7z to decompress the TAK release"
-		printf "%s\n" "$danger" "https://github.com/Cloud-RF/tak-server/blob/main/README.md"
+		printf $danger "\n .----------------.  .----------------.  .----------------.  .----------------.\n" 
+		printf $danger "| .--------------. || .--------------. || .--------------. || .--------------. |\n"
+		printf $danger "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |\n"
+		printf $danger "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |\n"
+		printf $danger "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |\n"
+		printf $danger "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |\n"
+		printf $danger "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |\n"
+		printf $danger "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |\n"
+		printf $danger "| |              | || |              | || |              | || |              | |\n"
+		printf $danger "| '--------------' || '--------------' || '--------------' || '--------------' |\n"
+		printf $danger " '----------------'  '----------------'  '----------------'  '----------------' \n"
+		printf $danger "You require either unzip OR 7z to decompress the TAK release\n"
+		printf $danger "https://github.com/Cloud-RF/tak-server/blob/main/README.md\n"
 		exit 1
-
 	else
 		7z x $release.zip -o/tmp/takserver
 	fi
@@ -197,20 +193,19 @@ fi
 
 if [ ! -d "/tmp/takserver/$release/tak" ] 
 then
-	printf "%s\n" "$danger" ""
-	printf "%s\n" "$danger" " .----------------.  .----------------.  .----------------.  .----------------."
-	printf "%s\n" "$danger" "| .--------------. || .--------------. || .--------------. || .--------------. |"
-	printf "%s\n" "$danger" "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |"
-	printf "%s\n" "$danger" "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |"
-	printf "%s\n" "$danger" "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |"
-	printf "%s\n" "$danger" "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |"
-	printf "%s\n" "$danger" "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |"
-	printf "%s\n" "$danger" "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |"
-	printf "%s\n" "$danger" "| |              | || |              | || |              | || |              | |"
-	printf "%s\n" "$danger" "| '--------------' || '--------------' || '--------------' || '--------------' |"
-	printf "%s\n" "$danger" " '----------------'  '----------------'  '----------------'  '----------------' "
-	printf "%s\n" "$danger" "A decompressed folder was NOT found at /tmp/takserver/$release"
-	printf "%s\n" "$danger" "https://github.com/Cloud-RF/tak-server/blob/main/README.md"
+	printf $danger "\n .----------------.  .----------------.  .----------------.  .----------------.\n" 
+	printf $danger "| .--------------. || .--------------. || .--------------. || .--------------. |\n"
+	printf $danger "| |  _______     | || |  _________   | || |  _________   | || | ____    ____ | |\n"
+	printf $danger "| | |_   __ \    | || | |  _   _  |  | || | |_   ___  |  | || ||_   \  /   _|| |\n"
+	printf $danger "| |   | |__) |   | || | |_/ | | \_|  | || |   | |_  \_|  | || |  |   \/   |  | |\n"
+	printf $danger "| |   |  __ /    | || |     | |      | || |   |  _|      | || |  | |\  /| |  | |\n"
+	printf $danger "| |  _| |  \ \_  | || |    _| |_     | || |  _| |_       | || | _| |_\/_| |_ | |\n"
+	printf $danger "| | |____| |___| | || |   |_____|    | || | |_____|      | || ||_____||_____|| |\n"
+	printf $danger "| |              | || |              | || |              | || |              | |\n"
+	printf $danger "| '--------------' || '--------------' || '--------------' || '--------------' |\n"
+	printf $danger " '----------------'  '----------------'  '----------------'  '----------------' \n"
+	printf $danger "A decompressed folder was NOT found at /tmp/takserver/$release\n"
+	printf $danger "https://github.com/Cloud-RF/tak-server/blob/main/README.md\n"
 	exit 1
 fi
 
@@ -239,7 +234,7 @@ pgpassword=$pgpwd"Meh1!"
 NIC=$(route | grep default | awk '{print $8}' | head -n 1)
 IP=$(ip addr show $NIC | grep -m 1 "inet " | awk '{print $2}' | cut -d "/" -f1)
 
-printf "%s\n" "$info" "\nProceeding with IP address: $IP\n"
+printf $info "\nProceeding with IP address: $IP\n"
 sed -i "s/password=\".*\"/password=\"${pgpassword}\"/" tak/CoreConfig.xml
 # Replaces HOSTIP for rate limiter and Fed server. Database URL is a docker alias of tak-database
 sed -i "s/HOSTIP/$IP/g" tak/CoreConfig.xml
@@ -260,7 +255,7 @@ fi
 sed -i "s%\`awk '/MemTotal/ {print \$2}' /proc/meminfo\`%$mem%g" tak/setenv.sh
 
 ## Set variables for generating CA and client certs
-printf "%s\n" "$warning" "SSL setup. Hit enter (x4) to accept the defaults:\n"
+printf $warning "SSL setup. Hit enter (x4) to accept the defaults:\n"
 read -p "Country (for cert generation). Default [US] : " country
 read -p "State (for cert generation). Default [state] : " state
 read -p "City (for cert generation). Default [city]: " city
@@ -312,7 +307,7 @@ $DOCKER_COMPOSE --file $DOCKERFILE up  --force-recreate -d
 while :
 do
 	sleep 10 # let the PG stderr messages conclude...
-	printf "%s\n" "$warning" "------------CERTIFICATE GENERATION--------------"
+	printf $warning "------------CERTIFICATE GENERATION--------------\n"
 	$DOCKER_COMPOSE exec tak bash -c "cd /opt/tak/certs && ./makeRootCa.sh --ca-name CRFtakserver"
 	if [ $? -eq 0 ];
 	then
@@ -335,7 +330,7 @@ do
 	fi
 done
 
-printf "%s\n" "$info" "Creating certificates for 2 users in tak/certs/files for a quick setup via TAK's import function\n"
+printf $info "Creating certificates for 2 users in tak/certs/files for a quick setup via TAK's import function\n"
 
 # Make 2 users
 cd tak/certs
@@ -348,7 +343,7 @@ cd ../../
 ./scripts/certDP.sh $IP user1
 ./scripts/certDP.sh $IP user2
 
-printf "%s\n" "$info" "Waiting for TAK server to go live. This should take <1m with an AMD64, ~2min on an ARM64 (Pi)"
+printf $info "Waiting for TAK server to go live. This should take <1m with an AMD64, ~2min on a ARM64 (Pi)\n"
 $DOCKER_COMPOSE start tak
 sleep 10
 
@@ -374,7 +369,7 @@ do
 			sleep 10
 		fi
 	else
-		printf "%s\n" "$info" "No joy with DB at $IP, will retry in 10s. If this loops more than 6 times, go and get some fresh air..." 
+		printf $info "No joy with DB at $IP, will retry in 10s. If this loops more than 6 times go and get some fresh air...\n" 
 	fi
 done
 
@@ -383,15 +378,15 @@ cp ./tak/certs/files/$user.p12 .
 ### Post-installation message to user including randomly generated passwrods to use for account and PostgreSQL
 docker container ls
 
-printf "%s\n\n" "$warning" "Import the $user.p12 certificate from this folder to your browser as per the README.md file"
-printf "%s\n" "$success" "Login at https://$IP:8443 with your admin account. No need to run the /setup step as this has been done."
-printf "%s\n\n" "$info" "Certificates and *CERT DATA PACKAGES* are in tak/certs/files"
-printf "%s\n\n" "$success" "Setup script sponsored by CloudRF.com - \"The API for RF\""
-printf "%s\n\n" "$danger" "---------PASSWORDS----------------"
-printf "%s\n" "$danger" "Admin user name: $user" # Web interface default user name
-printf "%s\n" "$danger" "Admin password: $password" # Web interface default random password created during setup
-printf "%s\n\n" "$danger" "PostgreSQL password: $pgpassword" # PostgreSQL password randomly generated during setup
-printf "%s\n\n" "$danger" "---------PASSWORDS----------------"
-printf "%s\n" "$warning" "MAKE A NOTE OF YOUR PASSWORDS. THEY WON'T BE SHOWN AGAIN."
-printf "%s\n" "$warning" "You have a database listening on TCP 5432 which requires a login. You should still block this port with a firewall"
-printf "%s\n" "$info" "Docker containers should automatically start with the Docker service from now on."
+printf $warning "\n\nImport the $user.p12 certificate from this folder to your browser as per the README.md file\n"
+printf $success "Login at https://$IP:8443 with your admin account. No need to run the /setup step as this has been done.\n" 
+printf $info "Certificates and *CERT DATA PACKAGES* are in tak/certs/files \n\n" 
+printf $success "Setup script sponsored by CloudRF.com - \"The API for RF\"\n\n"
+printf $danger "---------PASSWORDS----------------\n\n"
+printf $danger "Admin user name: $user\n" # Web interface default user name
+printf $danger "Admin password: $password\n" # Web interface default random password created during setup
+printf $danger "PostgreSQL password: $pgpassword\n\n" # PostgreSQL password randomly generated during set up
+printf $danger "---------PASSWORDS----------------\n\n"
+printf $warning "MAKE A NOTE OF YOUR PASSWORDS. THEY WON'T BE SHOWN AGAIN.\n"
+printf $warning "You have a database listening on TCP 5432 which requires a login. You should still block this port with a firewall\n"
+printf $info "Docker containers should automatically start with the Docker service from now on.\n"

--- a/tak-md5checksum.txt
+++ b/tak-md5checksum.txt
@@ -8,3 +8,4 @@ c07f01d74960287bfc7dc08ecd6cbc3a  takserver-docker-4.8-RELEASE-31.zip
 ecfc16b2daf78bdb8f10d99b8767deb7  takserver-docker-5.1-RELEASE-11.zip
 c6d1485ae3f81bd30c35be836a001cd0  takserver-docker-5.1-RELEASE-50.zip
 b691d1d7377790690e1e5ec0e4a29a56  takserver-docker-5.2-RELEASE-30.zip
+0a7398383253707dd7564afc88f29b3b  takserver-docker-5.2-RELEASE-43.zip

--- a/tak-sha1checksum.txt
+++ b/tak-sha1checksum.txt
@@ -8,3 +8,4 @@ f427ae3e860fddb8907047f157ada5764334c48d  takserver-docker-4.7-RELEASE-20.zip
 3fa400e96234a17fde2ad2c314b409973676c497  takserver-docker-5.1-RELEASE-11.zip
 99467f0be91e682714e72c34196c6d8bf40c92d3  takserver-docker-5.1-RELEASE-50.zip
 98f13f9140470ee65351e3d25dec097603bfb582  takserver-docker-5.2-RELEASE-30.zip
+824d7b89fbe6377cb5570f50bb35e6e05c12b230  takserver-docker-5.2-RELEASE-43.zip


### PR DESCRIPTION
Just added checksums for takserver-docker-5.2-RELEASE-43.zip.


How I obtained checksums:  
Downloaded build from TAK.gov , ran the following commands, with the following versions of sha1sum and md5sum. 

```
$ sha1sum --version
sha1sum (GNU coreutils) 9.5
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
$ md5sum --version
md5sum (GNU coreutils) 9.5
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
```


```
$ sha1sum takserver-docker-5.2-RELEASE-43.zip
824d7b89fbe6377cb5570f50bb35e6e05c12b230  takserver-docker-5.2-RELEASE-43.zip
$ md5sum takserver-docker-5.2-RELEASE-43.zip
0a7398383253707dd7564afc88f29b3b  takserver-docker-5.2-RELEASE-43.zip
```
